### PR TITLE
small apostrophe fix - php and encoding issue

### DIFF
--- a/includes/data.inc.php
+++ b/includes/data.inc.php
@@ -44,7 +44,7 @@ return array(
 );
 
 function preventOrphans($string) {
-	$string = htmlentities($string);
+	$string = htmlspecialchars($string);
 	$pattern = '/(.*) (\S*)$/i';
 	$replacement = '$1&nbsp;$2';
 	$string = preg_replace($pattern, $replacement, $string);


### PR DESCRIPTION
This should fix a small issue I noticed when some previous changes broke apostrophes in titles when deployed. I think the problem was that the server is running an older version of PHP than I am locally, so I didn't catch it before the last pull request. I reverted to a PHP version that had the same problem I was seeing on the site (PHP 5.2.17), and this change seems to have fixed it.

The problem is visible here: http://webtypography.net/3.1.1
