### PR TITLE
Updated gendered pronouns with their gender-neutral alternatives.

### DIFF
--- a/items/2.1.2.html
+++ b/items/2.1.2.html
@@ -14,7 +14,7 @@
   width:33em;
 }</code></pre>
 
-	<p>When typographers set the measure and text size for printed media, those dimensions are fixed and unchangeable in their physical manifestation. In this regard, the Web as viewed on-screen is fundamentally different to print because the medium is far more under the control of your readers. In particular, if your reader wishes to change the text size or the dimensions of the ‘page’, he can&nbsp;do.</p>
+	<p>When typographers set the measure and text size for printed media, those dimensions are fixed and unchangeable in their physical manifestation. In this regard, the Web as viewed on-screen is fundamentally different to print because the medium is far more under the control of your readers. In particular, if your reader wishes to change the text size or the dimensions of the ‘page’, they can&nbsp;do.</p>
 
 	<p>In the preceding example, column 1&nbsp;has a fixed width: it has been set to 400&nbsp;px wide.  With text rendering at 12&nbsp;px this would result in a measure of approximately 66&nbsp;characters per line. If your reader increases the text size to 16&nbsp;px then the measure reduces to 50&nbsp;characters per line. Thus when the text size is changed, so the measure&nbsp;changes.</p>
 
@@ -22,6 +22,6 @@
 
 	<p>Column 3&nbsp;has an elastic width: it has been set to 33&nbsp;em wide. On average one character takes up 0.5&nbsp;em so this box will have a measure of 66&nbsp;characters per line. If your reader increases the text size, the width of box will increase accordingly and so the measure remains at 66&nbsp;regardless of the text&nbsp;size.</p>
 
-	<p>From a typographical perspective, the most appropriate method is to set box width in ems <span class='bracket'>(</span>elastic layout<span class='bracket'>)</span> as it ensures the measure is always set to the typographer’s specification. Setting box width as a percentage <span class='bracket'>(</span>liquid layout<span class='bracket'>)</span> gives the typographer approximate control over measure but also allows the reader to adjust the layout to suit his or her comfort. This website has been designed with liquid layout to afford readers this&nbsp;control.</p>
+	<p>From a typographical perspective, the most appropriate method is to set box width in ems <span class='bracket'>(</span>elastic layout<span class='bracket'>)</span> as it ensures the measure is always set to the typographer’s specification. Setting box width as a percentage <span class='bracket'>(</span>liquid layout<span class='bracket'>)</span> gives the typographer approximate control over measure but also allows the reader to adjust the layout to suit their comfort. This website has been designed with liquid layout to afford readers this&nbsp;control.</p>
 
 	<p>Relinquishing such control makes some designers quake in their boots, but the beauty and advantage of the Web as a medium is that readers are able to adjust their reading environment to suit their own needs. This is a concept that should be acknowledged &#38; embraced, and built into website designs from the ground&nbsp;up.</p>


### PR DESCRIPTION
- Changed an instance of 'he' to 'they'
- Changed an instance of 'his or her' to 'their'

Reason: To make this guide more accessible to those that don't identify with binary gender pronouns.