### PR TITLE
Remove no-longer-true assertion about line-height

### DIFF
--- a/items/2.2.1.html
+++ b/items/2.2.1.html
@@ -10,7 +10,7 @@
 
 	<p>However <strong>that example is bad</strong> as <code>line-height</code> should never be applied using absolute units such as points or pixels. In the prior example, when text is resized in a browser, the font-size increases <span class='bracket'>(</span>to 18&nbsp;pt for example<span class='bracket'>)</span> but the line-height may remain at 15&nbsp;pt. So instead of the lines being spaced apart, they would actually&nbsp;overlap.</p>
 
-	<p>A better approach is to make use of a unique characteristic of the <code>line-height</code> property: it is the only <abbr title="Cascading Style Sheets">CSS</abbr> property for which non-zero numeric values are allowed without units. The preceding example could also be coded&nbsp;as:</p>
+	<p>A better approach is to use a unitless value. The preceding example could also be coded&nbsp;as:</p>
 
 <pre><code>p {
   font-size: 12pt;


### PR DESCRIPTION
Time has passed and now there are more properties that allow unitless
non-zero values.

Fixes #26.