### PR TITLE
Adjust layout for larger screens to handle column text length

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -93,8 +93,31 @@ img {
 	margin-left:61.8%;
 }
 
+@media (min-width: 80em) {
+	#supp {
+		margin-left: 780px;
+	}
+}
+
 #main h1, #main h2, #main p, #main pre, #main ul, #main ol, #main dl, #supp ul, #supp h3, #supp ol, #supp p, form, .example, #supp #deck {
 	padding: 0 11.8%;
+}
+
+@media (min-width: 80em) {
+	#main {
+		width: auto;
+	}
+
+	#main h1, #main h2, #main p, #main pre, #main ul, #main ol, #main dl, #supp ul, #supp h3, #supp ol, #supp p, form, .example, #supp #deck {
+		max-width: 780px;
+	}
+
+	h1 span,
+	#toc li span,
+	.thumb
+	{
+		max-width: 92px;
+	}
 }
 
 h1 span, #supp span, #toc li span, .quote-from-book .ic, .thumb {
@@ -567,6 +590,12 @@ div.ex2-1-9 {
 
 .ex2-2-2 .basictext {
 	margin-left: 10em;
+}
+
+@media (min-width: 80em) {
+	.ex2-2-2 .basictext {
+		max-width: 505px !important;
+	}
 }
 
 .ex2-2-2 .sidenote {


### PR DESCRIPTION
As pointed out in #23, when viewing the site on large screens, the column text length exceeds over 90 characters.

This pull request adjusts parts of the layout to a fixed size on screens larger than 1280px to match the layout when monitors were smaller (as the site was originally designed).

I attempted to fix some of the issues with table of content numbers & thumbnails (on large screens) from this change. The only other adjustment was to handle the Sidenote example on 2.2.2.

This does not handle any of the issues related to what happens in narrow widths as pointed out in https://github.com/clagnut/webtypography/issues/23#issuecomment-433756845.