### PR TITLE
Add item 3.2.3 - capitalization of acronyms, common acronyms and logograms

### DIFF
--- a/includes/data.inc.php
+++ b/includes/data.inc.php
@@ -14,7 +14,7 @@ return array(
         '3.1' => 'Size',
         '3.2' => 'Numerals, Capitals & Small Caps',
     ),
- 
+
     'items' => array(
 	    '2.1.1' => "Define the word space to suit the size and natural letterfit of the font",
 	    '2.1.2' => "Choose a comfortable measure",
@@ -39,8 +39,8 @@ return array(
 		'2.4.8' => "Never begin a page with the last line of a multi-line paragraph",
 		'3.1.1' => "Don’t compose without a scale",
 		'3.2.1' => "Use titling figures with full caps, and text figures in all other circumstances",
-    '3.2.2' => "For abbreviations and acronyms in the midst of normal text, use spaced small caps",
-
+		'3.2.2' => "For abbreviations and acronyms in the midst of normal text, use spaced small caps",
+		'3.2.3' => "Refer typographic disputes to the higher courts of speech and thinking",
     )
 );
 

--- a/items/3.2.3.html
+++ b/items/3.2.3.html
@@ -1,0 +1,7 @@
+<blockquote class='quote-from-book'>
+<p><span class='ic'>“</span>Type is idealized writing, and its normal function is to record idealized speech … When a writer accepts them fully into her speech and urges readers to do likewise, it is time for the typographer to accept them into the common speech of typography by setting them in lower case: Unesco, Ascii (or ascii) and Fortran. Other acronymic words, such as laser and radar, have long since traveled the same road.”</p></blockquote>
+
+
+<pre><code>text-transform: capitalize | uppercase | lowercase | none | inherit</code></pre>
+
+<p><code>capitalize</code> might work in some scenarios for acronymns and logograms like Unesco (not <span class="caps">UNESCO</span>) and Wordperfect (not WordPerfect). But it won't help with laser (not Laser or <span class="caps">LASER</span>) or radar (not Radar or <span class="caps">RADAR</span>). The text will probably have to be edited to produce the preferred capitalization in each case.</p>


### PR DESCRIPTION
"Refer typographic disputes to the higher courts of speech and thinking"

This one is pretty thin as there's not much CSS can do without knowing the
semantics of the text and even the particular state of a given acronym in the
popular imagination. But just skipping a section felt wrong too (?) so here it
is.